### PR TITLE
Fix json->gradle language mark

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ AdyenCSE is available through a gradle task. To install it, simply execute the f
 
 1. In your `build.gradle` of the root directory add the following line:
     
-    ```json
+    ```gradle
     buildscript {
         repositories {
             ...
@@ -33,7 +33,7 @@ AdyenCSE is available through a gradle task. To install it, simply execute the f
     
 2. In your `build.gradle` of the app module add the following task:
 
-    ```json
+    ```gradle
     import de.undercouch.gradle.tasks.download.Download
     
     ...
@@ -47,7 +47,7 @@ AdyenCSE is available through a gradle task. To install it, simply execute the f
    
 3. Next add the following snippet in your `build.gradle` of the app module:
 
-    ```json
+    ```gradle
     repositories {
         flatDir {
             dirs 'libs'


### PR DESCRIPTION
`json` language marking was used incorrectly for gradle (groovy) code, so Github.com displayed this readme file incorrectly with red `error` highlighting.